### PR TITLE
Add EmbSpatial-Bench dataset

### DIFF
--- a/tasks/embspatial_bench/embspatial_bench.py
+++ b/tasks/embspatial_bench/embspatial_bench.py
@@ -1,0 +1,15 @@
+config = dict(
+    dataset_path="HelloGitHub/EmbSpatial-Bench",
+    split="train",
+    processed_dataset_path="EmbSpatialBench",
+    processor="process.py",
+)
+
+dataset = dict(
+    type="VqaBaseDataset",
+    prompt_template=dict(type="PromptTemplate"),
+    config=config,
+    name="embspatial_bench",
+)
+
+evaluator = dict(type="BaseEvaluator", detailed_keys=["sub_task"])

--- a/tasks/embspatial_bench/process.py
+++ b/tasks/embspatial_bench/process.py
@@ -1,0 +1,76 @@
+import json
+import os
+import os.path as osp
+import base64
+from datasets import load_dataset
+
+
+DIRECTION_SET = {"left", "right", "above", "under"}
+DISTANCE_SET = {"close", "far"}
+ANSWER_LETTERS = ["A", "B", "C", "D"]
+
+
+def merge_relation(relation):
+    """将关系映射为更高层的类别"""
+    if relation in DIRECTION_SET:
+        return "direction"
+    elif relation in DISTANCE_SET:
+        return "distance"
+    else:
+        raise ValueError(f"Unknown relation: {relation}")
+
+
+def process(cfg):
+    """处理数据集并保存为标准格式"""
+    data_dir, split = cfg.dataset_path, cfg.split
+    name = cfg.get("dataset_name", "")
+
+    # 构建输出路径
+    output_dir = osp.join(cfg.processed_dataset_path, name, split)
+    img_dir = osp.join(output_dir, "img")
+    os.makedirs(img_dir, exist_ok=True)
+
+    # 加载数据集
+    data = load_dataset(data_dir, name=name, split=split)
+    content = []
+
+    # 处理每一条数据
+    for annotation in data:
+        question_id = annotation["question_id"]
+        img_name = f"img/{question_id}.png"
+
+        # 构建信息字典
+        info = {
+            "question": annotation["question"],
+            "answer": ANSWER_LETTERS[annotation["answer"]],
+            "question_id": question_id,
+            "img_path": img_name,
+            "relation": annotation["relation"],
+            "options": annotation["answer_options"],
+            "sub_task": merge_relation(annotation["relation"]),
+            "question_type": "multiple-choice",
+        }
+
+        # 保存图片
+        try:
+            image_data = base64.b64decode(annotation["image"])
+            with open(osp.join(output_dir, img_name), "wb") as image_file:
+                image_file.write(image_data)
+        except Exception as e:
+            print(f"Error saving image {question_id}: {e}")
+
+        # 格式化问题文本
+        question = info["question"]
+        if "options" in info:
+            options_text = "\n".join([f"{opt}" for opt in info["options"]])
+            question += f"\nOptions:\n{options_text}"
+
+        info["formatted_question"] = question
+        content.append(info)
+
+    # 保存处理后的数据
+    output_file = osp.join(output_dir, "data.json")
+    with open(output_file, "w") as f:
+        json.dump(content, f, indent=2)
+
+    print(f"Processed {len(content)} items. Data saved to {output_file}")

--- a/tasks/embspatial_bench/process.py
+++ b/tasks/embspatial_bench/process.py
@@ -11,7 +11,7 @@ ANSWER_LETTERS = ["A", "B", "C", "D"]
 
 
 def merge_relation(relation):
-    """将关系映射为更高层的类别"""
+    """Map relationships to higher-level categories"""
     if relation in DIRECTION_SET:
         return "direction"
     elif relation in DISTANCE_SET:
@@ -21,25 +21,25 @@ def merge_relation(relation):
 
 
 def process(cfg):
-    """处理数据集并保存为标准格式"""
+    """Process the dataset and save it in a standard format"""
     data_dir, split = cfg.dataset_path, cfg.split
     name = cfg.get("dataset_name", "")
 
-    # 构建输出路径
+    # build output path
     output_dir = osp.join(cfg.processed_dataset_path, name, split)
     img_dir = osp.join(output_dir, "img")
     os.makedirs(img_dir, exist_ok=True)
 
-    # 加载数据集
+    # load dataset
     data = load_dataset(data_dir, name=name, split=split)
     content = []
 
-    # 处理每一条数据
+    # process each item
     for annotation in data:
         question_id = annotation["question_id"]
         img_name = f"img/{question_id}.png"
 
-        # 构建信息字典
+        # build information dictionary
         info = {
             "question": annotation["question"],
             "answer": ANSWER_LETTERS[annotation["answer"]],
@@ -51,7 +51,7 @@ def process(cfg):
             "question_type": "multiple-choice",
         }
 
-        # 保存图片
+        # save image
         try:
             image_data = base64.b64decode(annotation["image"])
             with open(osp.join(output_dir, img_name), "wb") as image_file:
@@ -59,7 +59,7 @@ def process(cfg):
         except Exception as e:
             print(f"Error saving image {question_id}: {e}")
 
-        # 格式化问题文本
+        # format question
         question = info["question"]
         if "options" in info:
             options_text = "\n".join([f"{opt}" for opt in info["options"]])
@@ -68,7 +68,7 @@ def process(cfg):
         info["formatted_question"] = question
         content.append(info)
 
-    # 保存处理后的数据
+    # save data
     output_file = osp.join(output_dir, "data.json")
     with open(output_file, "w") as f:
         json.dump(content, f, indent=2)


### PR DESCRIPTION
Due to the inability to download the original [Phineas476/EmbSpatial-Bench](https://huggingface.co/datasets/Phineas476/EmbSpatial-Bench) dataset from Hugging Face, I have re-uploaded the dataset without any issues to [HelloGitHub/EmbSpatial-Bench](https://huggingface.co/datasets/HelloGitHub/EmbSpatial-Bench) to increase the flexibility of the task.

The evaluation results I obtained locally are as follows:
1. Qwen2-VL-7B-Instruct: {'accuracy': 63.65, 'direction': 71.08, 'distance': 48.67}
2. gpt-4o-mini: {'accuracy': 47.8, 'direction': 49.79, 'distance': 43.78}
3. Qwen2.5-VL-7B-Instruct：{'accuracy': 69.26, 'above': 77.01, 'close': 52.29, 'far': 54.04, 'left': 87.66, 'right': 79.19, 'under': 64.78}
