### PR TITLE
Support lmdeploy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.4/
 
 For detailed installation instructions, please refer to the [official SGLang documentation](https://sgl-project.github.io/start/install.html).
 
+#### LMDeploy Backend
+
+```bash
+pip install lmdeploy
+```
+
+For detailed installation instructions, please refer to the [official LMDeploy documentation](https://lmdeploy.readthedocs.io/en/latest/).
+
 #### Transformers
 
 For optimal performance for transformers, we recommend installing flash-attention

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -45,6 +45,14 @@ pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.4/
 
 详细安装说明请参考 [SGLang 官方文档](https://sgl-project.github.io/start/install.html)。
 
+#### LMDeploy 后端
+
+```bash
+pip install lmdeploy
+```
+
+详细安装说明请参考 [LMDeploy 官方文档](https://lmdeploy.readthedocs.io/en/latest/)。
+
 #### Transformers
 
 为获得最佳性能，我们建议安装 flash-attention

--- a/flagevalmm/server/model_server.py
+++ b/flagevalmm/server/model_server.py
@@ -27,11 +27,18 @@ class ModelServer:
     ):
         self.model_name = model_name
         self.port = port
-        assert backend in ["vllm", "sglang"], "backend must be vllm or sglang"
+        assert backend in [
+            "vllm",
+            "sglang",
+            "lmdeploy",
+        ], "backend must be vllm or sglang or lmdeploy"
+        self.backend = backend
         # extra args is like "--limit-mm-per-prompt image=8 --max-model-len 32768"
         splited_args = shlex.split(extra_args) if extra_args else []
-        if backend == "vllm":
+        if self.backend == "vllm":
             self.get_cmd = self.get_vllm_cmd
+        elif self.backend == "lmdeploy":
+            self.get_cmd = self.get_lmdeploy_cmd
         else:
             self.get_cmd = self.get_sglang_cmd
         self.execute_cmd = None
@@ -39,6 +46,18 @@ class ModelServer:
 
     def get_vllm_cmd(self, args: List):
         cmd = ["vllm", "serve", self.model_name, "--port", str(self.port), *args]
+        return cmd
+
+    def get_lmdeploy_cmd(self, args: List):
+        cmd = [
+            "lmdeploy",
+            "serve",
+            "api_server",
+            self.model_name,
+            "--server-port",
+            str(self.port),
+            *args,
+        ]
         return cmd
 
     def get_sglang_cmd(self, args: List):
@@ -117,13 +136,13 @@ class ModelServer:
     def cleanup(self):
         if hasattr(self, "server_process"):
             self.server_process.terminate()
-            logger.info("VLLM server terminated")
+            logger.info(f"{self.backend} server terminated")
             try:
                 # Wait for the process to terminate fully
                 self.server_process.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 logger.info(
-                    "VLLM server did not terminate within timeout, forcefully terminating"
+                    f"{self.backend} server did not terminate within timeout, forcefully terminating"
                 )
                 self.server_process.kill()
                 self.server_process.wait()


### PR DESCRIPTION
Run the vsi_bench_tiny dataset of Qwen2.5-VL-7B-Instruct with **vllm (0.8.2)**, the results are:
- accuracy: 26.34
- time: 595s

Run the vsi_bench_tiny dataset of Qwen2.5-VL-7B-Instruct with **lmdeploy (0.7.2.post1)**, the results are:
- accuracy: 27.96
- time: 262s

Execute command: `flagevalmm --tasks tasks/vsi_bench/vsi_bench_tiny.py --cfg lmdeploy-Qwen2.5-VL-7B-Instruct.json --output-dir /root/model_results/test/Qwen2.5-VL-7B-Instruct --exec model_zoo/vlm/api_model/model_adapter.py --backend lmdeploy`

`extra_args` parameter of model_config: ` "extra_args": "--session-len 32768 --max-batch-size 5"`