### PR TITLE
Add local mode && bug fix

### DIFF
--- a/flagevalmm/eval.py
+++ b/flagevalmm/eval.py
@@ -1,4 +1,3 @@
-import argparse
 import subprocess
 import requests
 import time
@@ -9,62 +8,11 @@ from mmengine.config import Config
 from flagevalmm.common.logger import get_logger
 from flagevalmm.server.utils import get_random_port
 from flagevalmm.registry import EVALUATORS, DATASETS
-from flagevalmm.server.utils import maybe_register_class, merge_args
+from flagevalmm.server.utils import maybe_register_class, merge_args, parse_args
 import os
 import signal
 
 logger = get_logger(__name__)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Infer a model")
-    parser.add_argument("--tasks", nargs="+", required=True, help="tasks to run")
-    parser.add_argument("--exec", type=str, help="model path in examples")
-    parser.add_argument("--debug", action="store_true", help="debug mode")
-    parser.add_argument(
-        "--try-run",
-        action="store_true",
-        help="try run mode, only run the first 32 samples",
-    )
-    parser.add_argument("--output-dir", type=str, help="output dir")
-    parser.add_argument("--data-root", type=str, help="data root")
-    parser.add_argument("--model", type=str, help="model name or path")
-    parser.add_argument(
-        "--model-type",
-        type=str,
-        default=None,
-        choices=["http", "claude", "gemini", "gpt", "hunyuan"],
-        help="type of the model",
-    )
-    parser.add_argument("--cfg", type=str, help="config file")
-    parser.add_argument("--num-workers", "--num-workers", type=int)
-    parser.add_argument("--backend", type=str)
-    parser.add_argument(
-        "--local-mode", "-l", action="store_true", help="run without evaluation server"
-    )
-    parser.add_argument("--disable-evaluation-server", "-ds", action="store_true")
-    parser.add_argument("--skip", action="store_true", help="skip finished tasks")
-    parser.add_argument("--server-port", type=int, help="port of evaluation server")
-    parser.add_argument(
-        "--server-ip",
-        type=str,
-        default="http://localhost",
-        help="ip of evaluation server",
-    )
-    parser.add_argument("--quiet", "-q", action="store_true", help="quiet mode")
-    parser.add_argument(
-        "--without-infer", "-wi", action="store_true", help="without inference"
-    )
-    parser.add_argument("--url", type=str, help="url of api model")
-    parser.add_argument("--api-key", type=str, help="api key of api model")
-    parser.add_argument(
-        "--use-cache", action="store_true", help="use cache of api model"
-    )
-    parser.add_argument(
-        "--extra-args", type=str, help="extra args of local server model"
-    )
-    args = parser.parse_args()
-    return args
 
 
 def update_cfg_from_args(args):
@@ -187,6 +135,7 @@ class ServerWrapper:
             command.extend(
                 [
                     "--local-mode",
+                    "True",
                     "--tasks",
                     *self.args.tasks,
                     "--output-dir",

--- a/flagevalmm/evaluator/mmmu_dataset_evaluator.py
+++ b/flagevalmm/evaluator/mmmu_dataset_evaluator.py
@@ -179,7 +179,10 @@ class MmmuEvaluator(BaseEvaluator):
             question_id = str(answer["question_id"])
             gt = annotation[question_id]
 
-            if gt["question_type"] == "multiple-choice":
+            if (
+                gt["question_type"] == "multiple-choice"
+                or gt["question_type"] == "vision"
+            ):
                 is_correct = self.evaluate_multiple_choice(gt, answer)
             else:
                 pred = parse_open_response(answer["answer"])

--- a/flagevalmm/models/base_model_adapter.py
+++ b/flagevalmm/models/base_model_adapter.py
@@ -248,9 +248,7 @@ class BaseModelAdapter:
             with self.accelerator.main_process_first():
                 dataset = dataset_cls(
                     task_name,
-                    self.server_ip,
-                    self.server_port,
-                    self.timeout,
+                    self.task_manager,
                     task_type=task_type,
                 )
                 data_loader = DataLoader(

--- a/flagevalmm/models/base_model_adapter.py
+++ b/flagevalmm/models/base_model_adapter.py
@@ -7,12 +7,112 @@ from torch.utils.data import DataLoader
 
 import os
 
-from flagevalmm.server.utils import get_meta, get_task_info, submit
-from flagevalmm.server.server_dataset import ServerDataset
+from flagevalmm.server.utils import get_meta, get_task_info, submit, get_data
 from flagevalmm.common.logger import get_logger
+from flagevalmm.server.evaluation_server import EvaluationServer
+from mmengine.config import Config
+from flagevalmm.server.utils import maybe_register_class
 
 os.environ["no_proxy"] = "127.0.0.1,localhost"
 logger = get_logger(__name__)
+
+
+def merge_args(
+    cfg: Config,
+    task_config_file: str,
+    data_root: Optional[str] = None,
+    debug: bool = False,
+) -> Config:
+    if data_root:
+        cfg.dataset.data_root = data_root
+    if debug:
+        cfg.dataset.debug = True
+    base_dir = osp.abspath(osp.dirname(task_config_file))
+    cfg.dataset.base_dir = base_dir
+    if cfg.get("evaluator", None):
+        cfg.evaluator.base_dir = base_dir
+    return cfg
+
+
+def load_tasks(
+    task_config_files: List[str], data_root: Optional[str] = None, debug: bool = False
+) -> Dict[str, Config]:
+    config_dict = {}
+    for task_config_file in task_config_files:
+        cfg = Config.fromfile(task_config_file, lazy_import=False)
+        task_name = cfg.dataset.name
+        cfg = merge_args(cfg, task_config_file, data_root, debug)
+        maybe_register_class(cfg, task_config_file)
+        config_dict[task_name] = cfg
+    logger.info(f"Loaded {len(config_dict)} tasks: {config_dict.keys()}")
+    return config_dict
+
+
+class TaskManager:
+    def __init__(
+        self,
+        server_ip: str,
+        server_port: int,
+        timeout: int = 1000,
+        local_mode: bool = False,
+        task_names: List[str] = None,
+        **kwargs,
+    ):
+        self.server_ip = server_ip
+        self.server_port = server_port
+        self.timeout = timeout
+        self.local_mode = local_mode
+        if local_mode:
+            assert task_names is not None, "task_names must be provided in local mode"
+        self.task_names = task_names
+        if local_mode:
+            config_dict = load_tasks(
+                task_names,
+                debug=kwargs.get("debug", False),
+                data_root=kwargs.get("data_root", None),
+            )
+
+            self.evaluation_server = EvaluationServer(
+                config_dict,
+                output_dir=kwargs.get("output_dir", None),
+                model_path=kwargs.get("model_path", None),
+                debug=kwargs.get("debug", False),
+                quiet=kwargs.get("quiet", False),
+                local_mode=True,
+            )
+
+    def get_task_info(self):
+        if not self.local_mode:
+            return get_task_info(self.server_ip, self.server_port)
+
+        task_info = {
+            "task_names": list(self.evaluation_server.config_dict.keys()),
+            "model_path": self.evaluation_server.model_path,
+        }
+        return task_info
+
+    def get_meta_info(self, task_name: str):
+        if not self.local_mode:
+            return get_meta(task_name, self.server_ip, self.server_port)
+        return self.evaluation_server.get_task_meta_info(task_name)
+
+    def submit(self, task_name: str, model_name: str, output_dir: str):
+        if not self.local_mode:
+            submit(
+                task_name,
+                model_name,
+                self.server_ip,
+                self.server_port,
+                self.timeout,
+                output_dir,
+            )
+        else:
+            self.evaluation_server.evaluate_task(task_name, model_name, output_dir)
+
+    def get_data(self, task_name: str, index: int):
+        if not self.local_mode:
+            return get_data(index, task_name, self.server_ip, self.server_port)
+        return self.evaluation_server.get_task_data_by_index(task_name, index)
 
 
 class BaseModelAdapter:
@@ -23,12 +123,21 @@ class BaseModelAdapter:
         timeout: int = 1000,
         enable_accelerate: bool = True,
         extra_cfg: str | Dict | None = None,
+        local_mode: bool = False,
+        task_names: List[str] = None,
+        **kwargs,
     ) -> None:
         self.server_ip: str = server_ip
         self.server_port: int = server_port
-
         self.timeout: int = timeout
-        task_info = get_task_info(server_ip, server_port)
+        self.task_manager = TaskManager(
+            server_ip,
+            server_port,
+            local_mode=local_mode,
+            task_names=task_names,
+            **kwargs,
+        )
+        task_info = self.task_manager.get_task_info()
         self.tasks = task_info["task_names"]
 
         if isinstance(extra_cfg, str):
@@ -63,9 +172,7 @@ class BaseModelAdapter:
 
     def run(self) -> None:
         for task_name in self.tasks:
-            meta_info: Dict[str, Any] = get_meta(
-                task_name, self.server_ip, self.server_port
-            )
+            meta_info: Dict[str, Any] = self.task_manager.get_meta_info(task_name)
             if "output_dir" in self.task_info:
                 meta_info["output_dir"] = osp.join(
                     self.task_info["output_dir"], task_name
@@ -78,12 +185,10 @@ class BaseModelAdapter:
             with open(osp.join(meta_info["output_dir"], "task_info.json"), "w") as f:
                 json.dump(task_info, f, indent=2, ensure_ascii=True)
             self.run_one_task(task_name, meta_info)
-            submit(
+            self.task_manager.submit(
                 task_name,
                 self.model_name,
-                server_ip=self.server_ip,
-                server_port=self.server_port,
-                output_dir=meta_info["output_dir"],
+                meta_info["output_dir"],
             )
 
     def run_one_task(self, task_name: str, meta_info: Dict[str, Any]) -> None:
@@ -132,7 +237,7 @@ class BaseModelAdapter:
 
     def create_data_loader(
         self,
-        dataset_cls: type[ServerDataset],
+        dataset_cls,
         task_name: str,
         task_type: str = "vqa",
         collate_fn: Optional[Callable] = None,

--- a/flagevalmm/models/http_client.py
+++ b/flagevalmm/models/http_client.py
@@ -54,7 +54,11 @@ class HttpClient(BaseApiModel):
         response = requests.post(
             self.url, headers=self.headers, data=json.dumps(data), timeout=300
         )
-        response_json = response.json()
+        try:
+            response_json = response.json()
+        except Exception as e:
+            raise Exception(f"Error: {response.text}, {e}")
+
         if response.status_code != 200:
             if "error" not in response_json:
                 yield f"Error code: {response_json['message']}"
@@ -74,7 +78,11 @@ class HttpClient(BaseApiModel):
         if "choices" in response_json:
             message = response_json["choices"][0]["message"]
             if "content" in message:
-                yield message["content"]
+                res = ""
+                if message.get("reasoning_content", None):
+                    res = f"<think>{message['reasoning_content']}</think>\n"
+                res += message["content"]
+                yield res
             else:
                 yield ""
         else:

--- a/flagevalmm/server/evaluation_server.py
+++ b/flagevalmm/server/evaluation_server.py
@@ -36,6 +36,7 @@ class EvaluationServer:
         host: str = "127.0.0.1",
         debug: bool = True,
         quiet: bool = False,
+        local_mode: bool = False,
     ) -> None:
         self.debug = debug
         self.port = port
@@ -46,16 +47,20 @@ class EvaluationServer:
         self.active_task: OrderedDict[str, Any] = OrderedDict()
         self.max_active_task_num = 10
         self.quiet = quiet
-        self.app = Flask(__name__)
+        if not local_mode:
+            self.app = Flask(__name__)
+        else:
+            self.app = None
         self.active_processes: Dict[str, multiprocessing.Process] = {}
 
         if self.quiet:
             # Disable Flask's default logging
-            self.app.logger.disabled = True
+            if self.app is not None:
+                self.app.logger.disabled = True
             log = logging.getLogger("werkzeug")
             log.disabled = True
-
-        self.set_routes()
+        if not local_mode:
+            self.set_routes()
 
     def load_dataset(self, task_name: str) -> None:
         logger.info(f"Loading dataset for task {task_name}")

--- a/flagevalmm/server/server_dataset.py
+++ b/flagevalmm/server/server_dataset.py
@@ -1,7 +1,5 @@
 from torch.utils.data import Dataset
 
-from flagevalmm.server.utils import get_meta, get_data
-
 
 class ServerDataset(Dataset):
     """
@@ -11,17 +9,14 @@ class ServerDataset(Dataset):
     def __init__(
         self,
         task_name: str,
-        server_ip: str = "http://localhost",
-        server_port: int = 5000,
-        timeout: int = 1000,
+        task_manager,
         task_type: str = "vqa",
     ) -> None:
-        self.server_ip = server_ip
-        self.server_port = server_port
-        self.timeout = timeout
+        # from flagevalmm.models.base_model_adapter import TaskManager
+        self.task_manager = task_manager
         self.task_name = task_name
         self.task_type = task_type
-        meta_info = get_meta(task_name, self.server_ip, self.server_port)
+        meta_info = self.task_manager.get_meta_info(task_name)
         self.datasetname = meta_info["name"]
         self.length: int = meta_info["length"]
 
@@ -41,5 +36,5 @@ class ServerDataset(Dataset):
         return question_id, multi_modal_data, qs
 
     def get_data(self, index: int):
-        data = get_data(index, self.task_name, self.server_ip, self.server_port)
+        data = self.task_manager.get_data(self.task_name, index)
         return data

--- a/flagevalmm/server/utils.py
+++ b/flagevalmm/server/utils.py
@@ -98,7 +98,7 @@ def parse_args():
     parser.add_argument("--num-workers", "--num_workers", type=int)
     parser.add_argument("--backend", type=str)
     parser.add_argument(
-        "--local-mode", "-l", action="store_true", help="run without evaluation server"
+        "--local-mode", type=bool, default=True, help="run without evaluation server"
     )
     parser.add_argument("--disable-evaluation-server", "-ds", action="store_true")
     parser.add_argument("--skip", action="store_true", help="skip finished tasks")

--- a/flagevalmm/server/utils.py
+++ b/flagevalmm/server/utils.py
@@ -75,18 +75,62 @@ def get_retrieval_data(
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Model Adapter")
-    parser.add_argument("--server_ip", type=str, default="http://localhost")
-    parser.add_argument("--server_port", type=int, default=5000)
-    parser.add_argument("--timeout", type=int, default=1000)
+    parser = argparse.ArgumentParser(description="Infer a model")
+    parser.add_argument("--tasks", nargs="+", help="tasks to run")
+    parser.add_argument("--exec", type=str, help="model path in examples")
+    parser.add_argument("--debug", action="store_true", help="debug mode")
     parser.add_argument(
-        "--cfg",
-        "-c",
+        "--try-run",
+        action="store_true",
+        help="try run mode, only run the first 32 samples",
+    )
+    parser.add_argument("--output-dir", type=str, help="output dir")
+    parser.add_argument("--data-root", type=str, help="data root")
+    parser.add_argument("--model", type=str, help="model name or path")
+    parser.add_argument(
+        "--model-type",
         type=str,
         default=None,
+        choices=["http", "claude", "gemini", "gpt", "hunyuan"],
+        help="type of the model",
     )
-    parser.add_argument("--num-workers", "--num-workers", type=int)
-    return parser.parse_args()
+    parser.add_argument("--cfg", "-c", type=str, help="config file")
+    parser.add_argument("--num-workers", "--num_workers", type=int)
+    parser.add_argument("--backend", type=str)
+    parser.add_argument(
+        "--local-mode", "-l", action="store_true", help="run without evaluation server"
+    )
+    parser.add_argument("--disable-evaluation-server", "-ds", action="store_true")
+    parser.add_argument("--skip", action="store_true", help="skip finished tasks")
+    parser.add_argument(
+        "--server-port",
+        "--server_port",
+        type=int,
+        help="port of evaluation server",
+        default=5000,
+    )
+    parser.add_argument(
+        "--server-ip",
+        "--server_ip",
+        type=str,
+        default="http://localhost",
+        help="ip of evaluation server",
+    )
+    parser.add_argument("--timeout", type=int, default=1000)
+    parser.add_argument("--quiet", "-q", action="store_true", help="quiet mode")
+    parser.add_argument(
+        "--without-infer", "-wi", action="store_true", help="without inference"
+    )
+    parser.add_argument("--url", type=str, help="url of api model")
+    parser.add_argument("--api-key", type=str, help="api key of api model")
+    parser.add_argument(
+        "--use-cache", action="store_true", help="use cache of api model"
+    )
+    parser.add_argument(
+        "--extra-args", type=str, help="extra args of local server model"
+    )
+    args = parser.parse_args()
+    return args
 
 
 def process_images_symbol(

--- a/model_zoo/t2i/custom_api/model_adapter.py
+++ b/model_zoo/t2i/custom_api/model_adapter.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import os.path as osp
 import json
@@ -6,21 +5,10 @@ import asyncio
 from typing import Dict
 from flagevalmm.models import Kolors, SenseMirage, HunyuanImage, DoubaoImage, Flux
 from flagevalmm.common.logger import get_logger
-from flagevalmm.server.utils import get_meta, submit, get_data
+from flagevalmm.server.utils import get_meta, submit, get_data, parse_args
 from flagevalmm.models.base_model_adapter import BaseModelAdapter
 
 logger = get_logger(__name__)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Infer a model")
-    parser.add_argument("--model-name", help="model name")
-    parser.add_argument(
-        "--server_ip", "--server-ip", type=str, default="http://localhost"
-    )
-    parser.add_argument("--server_port", "--server-port", type=int, default=5000)
-    parser.add_argument("--cfg", "-c", type=str, default=None)
-    return parser.parse_args()
 
 
 class ImageGenerator(BaseModelAdapter):
@@ -121,6 +109,13 @@ class ImageGenerator(BaseModelAdapter):
 if __name__ == "__main__":
     args = parse_args()
     generator = ImageGenerator(
-        server_ip=args.server_ip, server_port=args.server_port, extra_cfg=args.cfg
+        server_ip=args.server_ip,
+        server_port=args.server_port,
+        extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
     )
     generator.run()

--- a/model_zoo/t2i/flux/model_adapter.py
+++ b/model_zoo/t2i/flux/model_adapter.py
@@ -54,5 +54,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/t2i/http_image_api/model_adapter.py
+++ b/model_zoo/t2i/http_image_api/model_adapter.py
@@ -101,5 +101,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/t2i/stable_diffusion_v3/model_adapter.py
+++ b/model_zoo/t2i/stable_diffusion_v3/model_adapter.py
@@ -48,5 +48,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/uni/janus/model_adapter.py
+++ b/model_zoo/uni/janus/model_adapter.py
@@ -262,5 +262,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/vlm/Magma/model_adapter.py
+++ b/model_zoo/vlm/Magma/model_adapter.py
@@ -192,5 +192,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/vlm/Molmo/model_adapter.py
+++ b/model_zoo/vlm/Molmo/model_adapter.py
@@ -32,20 +32,6 @@ class CustomDataset(ServerDataset):
 
 
 class ModelAdapter(BaseModelAdapter):
-    def __init__(
-        self,
-        server_ip: str,
-        server_port: int,
-        timeout: int = 1000,
-        extra_cfg: str | Dict | None = None,
-    ) -> None:
-        super().__init__(
-            server_ip,
-            server_port,
-            timeout=timeout,
-            extra_cfg=extra_cfg,
-            enable_accelerate=False,
-        )
 
     def model_init(self, task_info: Dict):
         ckpt_path = task_info["model_path"]
@@ -103,5 +89,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/vlm/intern_vl/model_adapter.py
+++ b/model_zoo/vlm/intern_vl/model_adapter.py
@@ -98,5 +98,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/vlm/intern_vl/model_adapter_v2_5.py
+++ b/model_zoo/vlm/intern_vl/model_adapter_v2_5.py
@@ -279,5 +279,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/vlm/llama-vision/model_adapter.py
+++ b/model_zoo/vlm/llama-vision/model_adapter.py
@@ -136,5 +136,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()

--- a/model_zoo/vlm/qwen_vl/model_adapter.py
+++ b/model_zoo/vlm/qwen_vl/model_adapter.py
@@ -162,5 +162,11 @@ if __name__ == "__main__":
         server_port=args.server_port,
         timeout=args.timeout,
         extra_cfg=args.cfg,
+        local_mode=args.local_mode,
+        task_names=args.tasks,
+        output_dir=args.output_dir,
+        model_path=args.model,
+        debug=args.debug,
+        quiet=args.quiet,
     )
     model_adapter.run()


### PR DESCRIPTION
# Changes
1. Added Local Mode Support
   - Introduced new command-line flags `--local-mode True` to enable local evaluation without requiring an evaluation server
   - This feature allows users to run evaluations directly without launch evaluation server
   
   Example usage:
   ```bash
   flagevalmm --tasks tasks/mmmu/mmmu_val.py \
              --output-dir tmp \
              --cfg internal/model_configs/open/Qwen2.5-VL-7B-Instruct.json \
              --backend vllm \
              --local-mode True \
              --try-run
   ```

2. Enhanced Error Handling
   - Implemented additional try-catch mechanism to properly handle and cache API errors
   - Improves reliability and debugging capabilities when API calls fail
   
3. Fix mmmu_pro_vision evaluation bug