### PR TITLE
feat: Add streaming support for HttpClient

### DIFF
--- a/flagevalmm/models/base_api_model.py
+++ b/flagevalmm/models/base_api_model.py
@@ -26,6 +26,7 @@ class BaseApiModel:
         max_num_frames: Optional[int] = 8,
         use_cache: bool = False,
         stream: bool = False,
+        **kwargs,
     ) -> None:
         self.model_name = model_name
         self.chat_name = chat_name if chat_name else model_name
@@ -43,7 +44,8 @@ class BaseApiModel:
         }
         if max_tokens is not None:
             self.chat_args["max_tokens"] = max_tokens
-
+        if self.stream:
+            self.chat_args["stream"] = True
         self.cache = ModelCache(self.chat_name) if use_cache else None
 
     def add_to_cache(self, chat_messages, response) -> None:

--- a/flagevalmm/models/test_api_models.py
+++ b/flagevalmm/models/test_api_models.py
@@ -78,6 +78,16 @@ class TestClaudeModel(BaseTestModel, unittest.TestCase):
         )
 
 
+class TestHttpClientModelStream(BaseTestModel, unittest.TestCase):
+    def setUp(self):
+        self.model = HttpClient(
+            model_name="qvq-max",
+            api_key=os.environ.get("QWEN_API_KEY"),
+            url="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+            stream=True,
+        )
+
+
 class TestHttpClientModel(BaseTestModel, unittest.TestCase):
     def setUp(self):
         self.model = HttpClient(
@@ -93,4 +103,4 @@ class TestGeminiModel(BaseTestModel, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(defaultTest="TestHttpClientModel")
+    unittest.main(defaultTest="TestHttpClientModelStream")

--- a/flagevalmm/models/test_api_models.py
+++ b/flagevalmm/models/test_api_models.py
@@ -92,8 +92,8 @@ class TestHttpClientModel(BaseTestModel, unittest.TestCase):
     def setUp(self):
         self.model = HttpClient(
             model_name="gpt-4o-mini",
-            api_key=os.environ.get("BAAI_OPENAI_API_KEY"),
-            url="https://api.openai.com/v1/chat/completions",
+            api_key=os.environ.get("FLAGEVAL_API_KEY"),
+            url=os.environ.get("FLAGEVAL_URL"),
         )
 
 


### PR DESCRIPTION
feat: Add streaming support for `HttpClient`

## Summary
Implemented streaming response handling for the `HttpClient` class to support models that primarily deliver output via streaming, such as QVQ-Max.

## Background
QVQ-Max now primarily supports streaming output: https://help.aliyun.com/zh/model-studio/qvq?spm=a2c4g.11186623.help-menu-search-2400256.d_1#f508418722iy9

## Testing
To verify the implementation, run the following command:
```bash
python -m unittest flagevalmm.models.test_api_models.TestHttpClientModelStream
```

**Prerequisites:**
- Set the environment variable `QWEN_API_KEY` with your API key before running the tests

## Changes
- Added streaming response handling to the `HttpClient` class
- Properly handles different streaming response formats
- Supports reasoning content (think tags) in streaming responses
- Refactored code to improve maintainability