### PR TITLE
feat: save intermediate results

### DIFF
--- a/flagevalmm/dataset/vqa_base_dataset.py
+++ b/flagevalmm/dataset/vqa_base_dataset.py
@@ -42,7 +42,11 @@ class VqaBaseDataset(Dataset):
 
     def load_annotations(self, anno_file: Union[str, List[str]]):
         if isinstance(anno_file, str):
-            annotations = json.load(open(osp.join(self.data_root, anno_file)))
+            # if anno_file is absolute path, use it directly
+            if osp.isabs(anno_file):
+                annotations = json.load(open(anno_file))
+            else:
+                annotations = json.load(open(osp.join(self.data_root, anno_file)))
         else:
             annotations = []
             for file in anno_file:

--- a/flagevalmm/eval.py
+++ b/flagevalmm/eval.py
@@ -134,8 +134,6 @@ class ServerWrapper:
         if self.local_mode:
             command.extend(
                 [
-                    "--local-mode",
-                    "True",
                     "--tasks",
                     *self.args.tasks,
                     "--output-dir",

--- a/flagevalmm/models/base_model_adapter.py
+++ b/flagevalmm/models/base_model_adapter.py
@@ -214,6 +214,13 @@ class BaseModelAdapter:
             with open(output_file, "w") as f:
                 json.dump(result, f, indent=2, ensure_ascii=True)
 
+    def save_item(
+        self, result: Dict[str, Any], question_id: str, meta_info: Dict[str, Any]
+    ):
+        output_dir = osp.join(meta_info["output_dir"], "items")
+        with open(osp.join(output_dir, f"{question_id}.json"), "w") as f:
+            json.dump(result, f, indent=2, ensure_ascii=False)
+
     def collect_results_and_save(
         self,
         meta_info: Dict[str, Any],

--- a/flagevalmm/models/http_client.py
+++ b/flagevalmm/models/http_client.py
@@ -143,10 +143,9 @@ class HttpClient(BaseApiModel):
                                     think_start = False
                                 yield content
                     except json.JSONDecodeError as e:
-                        logger.warning(
+                        raise Exception(
                             f"Failed to parse chunk: {line_text}, error: {e}"
                         )
-                        continue
 
     def build_message(
         self,

--- a/flagevalmm/server/utils.py
+++ b/flagevalmm/server/utils.py
@@ -98,7 +98,10 @@ def parse_args():
     parser.add_argument("--num-workers", "--num_workers", type=int)
     parser.add_argument("--backend", type=str)
     parser.add_argument(
-        "--local-mode", type=bool, default=True, help="run without evaluation server"
+        "--no-local-mode",
+        action="store_false",
+        dest="local_mode",
+        help="disable local mode (use evaluation server)",
     )
     parser.add_argument("--disable-evaluation-server", "-ds", action="store_true")
     parser.add_argument("--skip", action="store_true", help="skip finished tasks")


### PR DESCRIPTION
## Changes:
- Added support for saving intermediate results during evaluation
- Fixed parameter handling bug in `eval.py` - changed `--local-mode` to use `--no-local-mode` flag instead, as the default value was already True and couldn't be properly overridden
- Enhanced error handling in streaming mode to propagate exceptions immediately rather than silently failing
