### PR TITLE
Support FlagScale backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ pip install lmdeploy
 
 For detailed installation instructions, please refer to the [official LMDeploy documentation](https://lmdeploy.readthedocs.io/en/latest/).
 
+
+#### FlagScale Backend
+
+```bash
+git clone https://github.com/FlagOpen/FlagScale.git
+cd FlagScale/install
+./install-requirements.sh --env inference
+cd vllm
+pip install .
+```
+
+For detailed installation instructions, please refer to the [official FlagScale documentation](https://lmdeploy.readthedocs.io/en/latest/).
+
 #### Transformers
 
 For optimal performance for transformers, we recommend installing flash-attention

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -53,6 +53,20 @@ pip install lmdeploy
 
 详细安装说明请参考 [LMDeploy 官方文档](https://lmdeploy.readthedocs.io/en/latest/)。
 
+
+#### FlagScale 后端
+
+```bash
+git clone https://github.com/FlagOpen/FlagScale.git
+cd FlagScale/install
+./install-requirements.sh --env inference
+cd vllm
+pip install .
+```
+
+详细安装说明请参考 [FlagScale 官方文档](https://github.com/FlagOpen/FlagScale)。
+
+
 #### Transformers
 
 为获得最佳性能，我们建议安装 flash-attention

--- a/flagevalmm/server/model_server.py
+++ b/flagevalmm/server/model_server.py
@@ -31,7 +31,8 @@ class ModelServer:
             "vllm",
             "sglang",
             "lmdeploy",
-        ], "backend must be vllm or sglang or lmdeploy"
+            "flagscale",
+        ], "backend must be vllm or sglang or lmdeploy or flagscale"
         self.backend = backend
         # extra args is like "--limit-mm-per-prompt image=8 --max-model-len 32768"
         splited_args = shlex.split(extra_args) if extra_args else []
@@ -39,6 +40,8 @@ class ModelServer:
             self.get_cmd = self.get_vllm_cmd
         elif self.backend == "lmdeploy":
             self.get_cmd = self.get_lmdeploy_cmd
+        elif self.backend == "flagscale":
+            self.get_cmd = self.get_flagscale_cmd
         else:
             self.get_cmd = self.get_sglang_cmd
         self.execute_cmd = None
@@ -56,6 +59,15 @@ class ModelServer:
             self.model_name,
             "--server-port",
             str(self.port),
+            *args,
+        ]
+        return cmd
+
+    def get_flagscale_cmd(self, args: List):
+        cmd = [
+            "flagscale",
+            "serve",
+            self.model_name,
             *args,
         ]
         return cmd

--- a/model_zoo/vlm/api_model/model_adapter.py
+++ b/model_zoo/vlm/api_model/model_adapter.py
@@ -83,7 +83,10 @@ class ModelAdapter(BaseModelAdapter):
         self.model = model_type_map[model_type](**model_config)
 
     def launch_model(self, task_info: Dict):
-        port = get_random_port()
+        if task_info.get("server_port"):
+            port = task_info.get("server_port")
+        else:
+            port = get_random_port()
         # replace port in url
         url = re.sub(
             r":(\d+)/",


### PR DESCRIPTION
Execute command: `flagevalmm --tasks tasks/mmmu/mmmu_val.py --cfg /path/flagscale-Qwen2.5-VL-7B-Instruct.json --exec model_zoo/vlm/api_model/model_adapter.py --backend flagscale --try-run`

Config `flagscale-Qwen2.5-VL-7B-Instruct.json`: 
```
{
    "model_name": "Qwen2.5-VL-7B-Instruct",
    "api_key": "EMPTY",
    "url": "http://localhost:8000/v1/chat/completions",
    "output_dir": "/path/Qwen2.5-VL-7B-Instruct",
    "num_workers": 8,
    "server_port": 8000,  # important
    "extra_args": "/path/FlagScale/examples/qwen/conf/config_qwen2.5_7b.yaml"
}
```

Magic code line: https://github.com/FlagOpen/FlagScale/blob/eb8558a73291fd5b922b83dec34acc18facc1f20/flagscale/runner/runner_serve.py#L317

