### PR TITLE
Support multi-inference for one sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,4 @@ ChangeLog
 internal
 
 # results
-results/
-
-.json
+result*/

--- a/README_MULTI_INFERENCE.md
+++ b/README_MULTI_INFERENCE.md
@@ -1,0 +1,66 @@
+# Multiple Inference Feature
+
+Due to variation of reasoning model's output, we need to perform multiple inferences for each question when temperature >= 0, and evaluate the results by taking the average accuracy.
+
+This document describes the multiple inference feature that allows models to perform multiple inferences for each question when temperature >= 0, and evaluates the results by taking the average accuracy.
+
+## Overview
+
+When `temperature >= 0` and `num_infers > 1`, the model will perform multiple inferences for each question and calculate the average accuracy score across all inferences.
+
+## How to use
+
+Use `MultiInferenceEvaluator` as the evaluator:
+
+```python
+## blink.py
+task_name = "vqa"
+
+config = dict(
+    dataset_path="BLINK-Benchmark/BLINK",
+    split="val",
+    processed_dataset_path="BLINK",
+    processor="process.py",
+)
+
+dataset = dict(
+    type="VqaBaseDataset",
+    config=config,
+    prompt_template=dict(
+        type="PromptTemplate",
+        post_prompt="The last line of your response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER is one of options.",
+    ),
+    name="blink_val",
+)
+
+evaluator = dict(type="MultiInferenceEvaluator", detailed_keys=["sub_task"])
+
+```
+
+When start a task, add "nums-infer" argument and add `temperature` in --extra-args, such as: 
+
+```bash
+flagevalmm --tasks tasks/blink/blink_val.py  --exec model_zoo/vlm/api_model/model_adapter.py --model gpt-4o-mini --num-workers 8 --output-dir ./results_temperature/gpt-4o-mini --url openai_url --api-key openai_api_key --num-infers 3 --try-run --use-cache --extra-args "temperature=0.6"
+```
+
+## Output Format
+
+For each question with multiple inferences, the result includes:
+
+```json
+{
+    "question_id": "q1",
+    "question": "What is this?",
+    "answer": {
+        "inference_0": "extracted_result1",
+        "inference_1": "extracted_result2", 
+        "inference_2": "extracted_result3",
+        "inference_3": "extracted_result4",
+        "inference_4": "extracted_result5"
+    },
+    "multiple_answers": ["result1", "result2", "result3", "result4", "result5"],
+    "correct": 0.8,
+    "inference_scores": [1, 1, 0, 1, 1],
+    "num_inferences": 5
+}
+```

--- a/flagevalmm/eval.py
+++ b/flagevalmm/eval.py
@@ -17,7 +17,15 @@ logger = get_logger(__name__)
 
 def update_cfg_from_args(args):
     cfg = json.load(open(args.cfg)) if args.cfg else {}
-    keys = ["num_workers", "backend", "url", "api_key", "use_cache", "extra_args"]
+    keys = [
+        "num_workers",
+        "backend",
+        "url",
+        "api_key",
+        "use_cache",
+        "extra_args",
+        "num_infers",
+    ]
     for key in keys:
         if getattr(args, key):
             cfg[key] = getattr(args, key)

--- a/flagevalmm/evaluator/__init__.py
+++ b/flagevalmm/evaluator/__init__.py
@@ -9,6 +9,7 @@ from .aggregation_evaluator import AggregationEvaluator
 from .one_align_evaluator import OneAlignEvaluator
 from .video_score_evaluator import VideoScoreEvaluator
 from .extract_evaluator import ExtractEvaluator
+from .multi_inference_evaluator import MultiInferenceEvaluator
 
 __all__ = [
     "BaseEvaluator",
@@ -22,4 +23,5 @@ __all__ = [
     "OneAlignEvaluator",
     "VideoScoreEvaluator",
     "ExtractEvaluator",
+    "MultiInferenceEvaluator",
 ]

--- a/flagevalmm/evaluator/multi_inference_evaluator.py
+++ b/flagevalmm/evaluator/multi_inference_evaluator.py
@@ -1,0 +1,235 @@
+import json
+from collections import defaultdict
+from typing import Callable, Optional, Dict, List, Tuple, Union
+import os.path as osp
+from flagevalmm.evaluator.base_evaluator import BaseEvaluator
+from flagevalmm.registry import EVALUATORS
+from flagevalmm.common.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@EVALUATORS.register_module()
+class MultiInferenceEvaluator(BaseEvaluator):
+    """
+    Multi-inference evaluator for evaluating the accuracy of model's multiple inference results.
+    """
+
+    def __init__(
+        self,
+        is_clean: bool = True,
+        use_llm_evaluator: bool = False,
+        eval_func: Optional[Union[Callable, str]] = None,
+        base_dir: str = "",
+        detailed_keys: Optional[List[str]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            is_clean=is_clean,
+            use_llm_evaluator=use_llm_evaluator,
+            eval_func=eval_func,
+            base_dir=base_dir,
+            detailed_keys=detailed_keys,
+            **kwargs,
+        )
+
+    def expand_multi_inference_predictions(
+        self, predictions: List[Dict]
+    ) -> Tuple[List[Dict], Dict]:
+        """
+        Expand multiple inference predictions into individual predictions.
+
+        Returns:
+            expanded_predictions: List of individual predictions
+            question_mapping: Mapping from expanded prediction index to original question info
+        """
+        expanded_predictions = []
+        question_mapping = {}
+
+        for pred in predictions:
+            multiple_answers = pred.get("multiple_answers", [pred["answer"]])
+
+            if len(multiple_answers) == 1:
+                # Single inference - keep as is
+                expanded_predictions.append(pred)
+                question_mapping[len(expanded_predictions) - 1] = {
+                    "original_question_id": pred["question_id"],
+                    "is_multi_inference": False,
+                    "inference_index": 0,
+                    "total_inferences": 1,
+                }
+            else:
+                # Multiple inferences - expand into separate predictions
+                for idx, answer in multiple_answers.items():
+                    i = int(idx.split("_")[-1])
+                    expanded_pred = pred.copy()
+                    expanded_pred["answer"] = answer
+                    expanded_pred["question_id"] = (
+                        f"{pred['question_id']}_inference_{i}"
+                    )
+                    expanded_predictions.append(expanded_pred)
+
+                    question_mapping[len(expanded_predictions) - 1] = {
+                        "original_question_id": pred["question_id"],
+                        "is_multi_inference": True,
+                        "inference_index": i,
+                        "total_inferences": len(multiple_answers),
+                    }
+
+        return expanded_predictions, question_mapping
+
+    def aggregate_multi_inference_results(
+        self, expanded_predictions: List[Dict], question_mapping: Dict
+    ) -> Tuple[List[Dict], Dict]:
+        """
+        Aggregate results from expanded predictions back to original questions.
+
+        Returns:
+            aggregated_predictions: List of predictions with aggregated results
+            stats: Statistics about the evaluation
+        """
+        # Group results by original question ID
+        question_results = defaultdict(list)
+
+        for i, pred in enumerate(expanded_predictions):
+            mapping = question_mapping[i]
+            original_qid = mapping["original_question_id"]
+
+            question_results[original_qid].append(
+                {
+                    "inference_index": mapping["inference_index"],
+                    "correct": pred["correct"],
+                    "answer": pred["answer"],
+                    "is_multi_inference": mapping["is_multi_inference"],
+                    "total_inferences": mapping["total_inferences"],
+                    "expanded_pred": pred,
+                }
+            )
+
+        # Aggregate results
+        aggregated_predictions = []
+        single_inference_count = 0
+        multi_inference_count = 0
+
+        for original_qid, results in question_results.items():
+            results.sort(key=lambda x: x["inference_index"])  # Ensure correct order
+
+            if results[0]["is_multi_inference"]:
+                # Multiple inference case - take average
+                inference_scores = [r["correct"] for r in results]
+                average_accuracy = sum(inference_scores) / len(inference_scores)
+
+                # Create aggregated prediction
+                base_pred = results[0]["expanded_pred"].copy()
+                base_pred["question_id"] = original_qid
+                base_pred["correct"] = average_accuracy
+                base_pred["answer"] = {
+                    f"inference_{idx}": r["answer"] for idx, r in enumerate(results)
+                }
+                base_pred["inference_scores"] = inference_scores
+                base_pred["num_inferences"] = len(results)
+
+                aggregated_predictions.append(base_pred)
+                multi_inference_count += 1
+            else:
+                # Single inference case
+                base_pred = results[0]["expanded_pred"].copy()
+                base_pred["question_id"] = original_qid
+                aggregated_predictions.append(base_pred)
+                single_inference_count += 1
+
+        stats = {
+            "single_inference_count": single_inference_count,
+            "multi_inference_count": multi_inference_count,
+            "total_questions": len(question_results),
+        }
+
+        return aggregated_predictions, stats
+
+    def process(self, dataset, output_dir, **kwargs):
+        """
+        Process dataset evaluation using BaseEvaluator's eval_func method.
+        """
+        annotation = dataset.get_annotation()
+        dataset_name = dataset.name
+        result_file = osp.join(output_dir, f"{dataset_name}.json")
+
+        if not osp.exists(result_file):
+            logger.error(f"Result file not found: {result_file}")
+            return {}
+
+        predictions = json.load(open(result_file))
+
+        # Step 1: Expand multiple inference predictions
+        expanded_predictions, question_mapping = (
+            self.expand_multi_inference_predictions(predictions)
+        )
+        logger.info(
+            f"Expanded {len(predictions)} predictions to {len(expanded_predictions)} individual evaluations"
+        )
+
+        # Step 2: Create annotation mapping for expanded predictions
+        expanded_annotations = {}
+        for pred in expanded_predictions:
+            # Extract original question ID from expanded question ID
+            qid = pred["question_id"]
+            if "_inference_" in qid:
+                original_qid = qid.split("_inference_")[0]
+            else:
+                original_qid = qid
+            expanded_annotations[qid] = annotation[original_qid]
+
+        # Step 3: Filter rejected predictions (following BaseEvaluator pattern)
+        results = {}
+        expanded_predictions, filtered_predictions = self.filter_rejected(
+            expanded_predictions, results
+        )
+
+        # Step 4: Use eval_func to compute results (following BaseEvaluator pattern)
+        if self.use_llm_evaluator:
+            base_results = self.eval_func(
+                expanded_annotations, expanded_predictions, self.llm_evaluator
+            )
+        else:
+            base_results = self.eval_func(expanded_annotations, expanded_predictions)
+
+        # Step 5: Aggregate results back to original questions
+        aggregated_predictions, stats = self.aggregate_multi_inference_results(
+            expanded_predictions, question_mapping
+        )
+
+        results.update(base_results)
+
+        total_score = sum(pred["correct"] for pred in aggregated_predictions)
+        total_questions = len(aggregated_predictions)
+        overall_accuracy = (
+            round(total_score / total_questions * 100, 2)
+            if total_questions > 0
+            else 0.0
+        )
+
+        results.update(
+            {
+                "overall_accuracy": overall_accuracy,
+                "total_questions": total_questions,
+                "total_score": total_score,
+                "single_inference_count": stats["single_inference_count"],
+                "multi_inference_count": stats["multi_inference_count"],
+            }
+        )
+
+        all_predictions = aggregated_predictions + filtered_predictions
+        self.save(results, all_predictions, dataset_name, output_dir)
+
+        logger.info(f"Overall Accuracy: {results.get('overall_accuracy', 0):.2f}%")
+
+        if "multi_inference_accuracy" in results:
+            logger.info(
+                f"Multi-inference Accuracy: {results['multi_inference_accuracy']:.2f}%"
+            )
+        if "single_inference_accuracy" in results:
+            logger.info(
+                f"Single-inference Accuracy: {results['single_inference_accuracy']:.2f}%"
+            )
+
+        return results

--- a/flagevalmm/server/utils.py
+++ b/flagevalmm/server/utils.py
@@ -132,6 +132,12 @@ def parse_args():
     parser.add_argument(
         "--extra-args", type=str, help="extra args of local server model"
     )
+    parser.add_argument(
+        "--num-infers",
+        type=int,
+        default=1,
+        help="number of inferences to perform for each question (when temperature >= 0)",
+    )
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
### 1. BaseApiModel Changes

- Added `num_infers` parameter to control the number of inferences
- Modified `infer` method to support multiple inferences
- Returns a list of results when `num_infers > 1`, single result when `num_infers = 1`

### 2. ModelAdapter Changes

- Added support for `num_infers` parameter in model configuration
- Modified `process_single_item` to handle multiple inference results
- Stores all inference results in `multiple_answers` field

### 3. MultiInferenceEvaluator

- New evaluator specifically designed for multiple inference evaluation
- **Uses BaseEvaluator's `eval_func` pattern for maximum compatibility**
- Uses data preprocessing and postprocessing approach:
  1. Expands multiple inference predictions into individual predictions, and calls `eval_func` method to evaluate individual predictions (supports both standard and LLM evaluation)
  2. Aggregates results back to original questions with average scoring
- Provides detailed statistics for both single and multiple inference cases