### PR TITLE
Add RealWorldQA dataset

### DIFF
--- a/tasks/realworldqa/process.py
+++ b/tasks/realworldqa/process.py
@@ -1,0 +1,36 @@
+import json
+import os
+import os.path as osp
+
+from datasets import load_dataset
+
+
+def process(cfg):
+    """Process the dataset and save it in a standard format"""
+    data_dir, split = cfg.dataset_path, cfg.split
+    name = cfg.get("dataset_name", "")
+
+    # build output path
+    output_dir = osp.join(cfg.processed_dataset_path, name, split)
+    img_dir = osp.join(output_dir, "img")
+    os.makedirs(img_dir, exist_ok=True)
+    # load dataset
+    data = load_dataset(data_dir, name=name, split=split)
+
+    content = []
+    for index, annotation in enumerate(data):
+        img_path = osp.join("img", annotation["image_path"])
+        info = {
+            "question": annotation["question"],
+            "question_id": index,
+            "question_type": "open",
+            "img_path": img_path,
+            "answer": annotation["answer"],
+        }
+        annotation["image"].save(osp.join(img_dir, annotation["image_path"]))
+        content.append(info)
+    output_file = osp.join(output_dir, "data.json")
+    with open(output_file, "w") as f:
+        json.dump(content, f, indent=2, ensure_ascii=False)
+
+    print(f"Processed {len(content)} items. Data saved to {output_file}")

--- a/tasks/realworldqa/realworldqa_test.py
+++ b/tasks/realworldqa/realworldqa_test.py
@@ -1,0 +1,15 @@
+config = dict(
+    dataset_path="lmms-lab/RealWorldQA",
+    split="test",
+    processed_dataset_path="RealWorldQA",
+    processor="process.py",
+)
+
+dataset = dict(
+    type="VqaBaseDataset",
+    prompt_template=dict(type="PromptTemplate", post_prompt=""),
+    config=config,
+    name="realworldqa",
+)
+
+evaluator = dict(type="BaseEvaluator")


### PR DESCRIPTION
This commit integrates [RealWorldQA](https://huggingface.co/datasets/lmms-lab/RealWorldQA), The evaluation results:

| Model Name             | Type         | Mean Accuracy  | 
|------------------------|--------------|---------|
|  Grok-1.5V | Proprietary|  68.7|
| o4-mini-2025-04-16            | API          | 73.92   |
| Qwen2.5-VL-7B-Instruct | Open Source  | 69.02   |

The Grok-1.5V result(68.7) is from the [official announcement by xAI](https://x.ai/news/grok-1.5v).

Example:

```
flagevalmm --tasks tasks/realworldqa/realworldqa_test.py \                                                                      
        --exec model_zoo/vlm/api_model/model_adapter.py \
        --model o4-mini-2025-04-16 \
        --num-workers 4 \
        --output-dir ./results/o4-mini-2025-04-16 \
        --url xxxx \
        --api-key xxxx
```