### PR TITLE
fix output length bug

### DIFF
--- a/model_zoo/vlm/api_model/model_adapter.py
+++ b/model_zoo/vlm/api_model/model_adapter.py
@@ -216,11 +216,6 @@ class ModelAdapter(BaseModelAdapter):
             usage=final_usage,
         )
 
-        # Save intermediate results using ProcessResult data
-        item_data = process_result.to_dict()
-        with open(inter_results_file, "w") as f:
-            json.dump(item_data, f, indent=2, ensure_ascii=False)
-
         return process_result
 
     def cleanup(self):
@@ -250,13 +245,14 @@ class ModelAdapter(BaseModelAdapter):
 
             for future in as_completed(future_to_item):
                 result = future.result()
+                results.append(result)
                 if isinstance(result.answer, str) and result.answer.startswith(
                     "Error code"
                 ):
                     continue
                 else:
                     self.save_item(result, result.question_id, meta_info)
-                results.append(result)
+
         self.save_result(results, meta_info)
 
 


### PR DESCRIPTION
This PR addresses an issue where model inference failures cause output length mismatches.

When model inference fails, the result is not saved, which leads to a length mismatch between annotations and predictions. This triggers an assertion error:

```
File "FlagEvalMM/flagevalmm/evaluator/base_evaluator.py", line 263, in
assert len(annotations) == len(predictions)
```