### PR TITLE
add mmsi_bench dataset

### DIFF
--- a/tasks/mmsi_bench/mmsi_bench.py
+++ b/tasks/mmsi_bench/mmsi_bench.py
@@ -1,4 +1,3 @@
-
 config = dict(
     dataset_path="RunsenXu/MMSI-Bench",
     split="test",

--- a/tasks/mmsi_bench/mmsi_bench.py
+++ b/tasks/mmsi_bench/mmsi_bench.py
@@ -1,0 +1,20 @@
+from tasks.where2place.where2place import post_prompt
+
+config = dict(
+    dataset_path="RunsenXu/MMSI-Bench",
+    split="test",
+    processed_dataset_path="MMSI-Bench",
+    processor="process.py",
+)
+
+dataset = dict(
+    type="VqaBaseDataset",
+    prompt_template=dict(
+        type="PromptTemplate",
+        post_prompt="Answer with the option's letter from the given choices directly. Enclose the option's letter within ``."
+    ),
+    config=config,
+    name="MMSI-Bench",
+)
+
+evaluator = dict(type="BaseEvaluator")

--- a/tasks/mmsi_bench/mmsi_bench.py
+++ b/tasks/mmsi_bench/mmsi_bench.py
@@ -1,4 +1,3 @@
-from tasks.where2place.where2place import post_prompt
 
 config = dict(
     dataset_path="RunsenXu/MMSI-Bench",
@@ -11,7 +10,7 @@ dataset = dict(
     type="VqaBaseDataset",
     prompt_template=dict(
         type="PromptTemplate",
-        post_prompt="Answer with the option's letter from the given choices directly. Enclose the option's letter within ``."
+        post_prompt="Answer with the option's letter from the given choices directly. Enclose the option's letter within ``.",
     ),
     config=config,
     name="MMSI-Bench",

--- a/tasks/mmsi_bench/process.py
+++ b/tasks/mmsi_bench/process.py
@@ -1,0 +1,57 @@
+import json
+import os
+import os.path as osp
+from typing import List
+
+from datasets import load_dataset
+
+
+def save_image(question_id, images, output_dir) -> List[str]:
+    img_path_list = []
+    for i, image in enumerate(images):
+        image_path = osp.join("img", f"{question_id}_{i + 1}.jpg")
+        img_path_list.append(image_path)
+        full_image_path = osp.join(output_dir, image_path)
+        os.makedirs(osp.dirname(full_image_path), exist_ok=True)
+        try:
+            if image.mode == "RGBA":
+                image = image.convert("RGB")
+            image.save(full_image_path)
+        except Exception as e:
+            print(f"Error saving image {question_id}: {e}")
+    return img_path_list
+
+
+def process(cfg):
+    """Process the dataset and save it in a standard format"""
+    data_dir, split = cfg.dataset_path, cfg.split
+    name = cfg.get("dataset_name", "")
+
+    # build output path
+    output_dir = osp.join(cfg.processed_dataset_path, name, split)
+    img_dir = osp.join(output_dir, "img")
+    os.makedirs(img_dir, exist_ok=True)
+    # load dataset
+    data = load_dataset(data_dir, name=name, split=split)
+
+    content = []
+    for annotation in data:
+        question_id = annotation["id"]
+        question = annotation["question"]
+        item = {
+            "question_id": question_id,
+            "sub_task": annotation["question_type"],
+            "answer": annotation["answer"],
+            "question_type": "multiple-choice",
+            "img_path": save_image(question_id, annotation["images"], output_dir),
+        }
+        img_prefix = ""
+        for i in range(len(item["img_path"])):
+            img_prefix += f"<image {i + 1}> "
+        item["question"] = img_prefix + question
+        content.append(item)
+    output_file = osp.join(output_dir, "data.json")
+    with open(output_file, "w") as f:
+        json.dump(content, f, indent=2, ensure_ascii=False)
+
+    print(f"Processed {len(content)} items. Data saved to {output_file}")


### PR DESCRIPTION
This commit integrates [MMSI-Bench](https://huggingface.co/datasets/RunsenXu/MMSI-Bench), The evaluation results:

| Model Name             | Type         | FlagEvalMM Accuracy  |  Office Accuracy  |
|------------------------|--------------|--------------|--------------|
| Qwen2.5-VL-7B-Instruct | Open Source  | 28.5   | 25.9 |
| Qwen2.5-VL-3B-Instruct | Open Source  | 27.6   | 26.5 |

Example:

```
 flagevalmm --tasks tasks/mmsi_bench/mmsi_bench.py \
        --exec model_zoo/vlm/api_model/model_adapter.py \
        --model gemini-2.5-pro \
        --num-workers 4 \
        --output-dir ./results/gemini-2.5-pro \
        --url https://api.xxxx/v1/chat/completions \
        --api-key xxx
```

