### PR TITLE
refactor: unified argument parsing with OmegaConf and YAML configs

### DIFF
--- a/model_configs/Qwen2.5-VL-7B-Instruct-vllm.yaml
+++ b/model_configs/Qwen2.5-VL-7B-Instruct-vllm.yaml
@@ -1,0 +1,26 @@
+tasks:
+  files:
+    - tasks/blink/blink_val.py
+  data_root: /data/BLINK/val/
+  debug: false
+  try_run: true
+  output_dir: outputs/demo_run_5
+  num_workers: 8
+
+server:
+  local_mode: true
+  quiet: false
+
+model:
+  model_type: http
+  model_name: /share/project/models/vlm/Qwen2.5-VL-7B-Instruct
+  url: http://localhost:8000/v1/chat/completions
+  api_key: EMPTY
+  backend: vllm
+  extra_args: "--max-model-len 32768"
+
+infer:
+  use_cache: false
+  temperature: 0.2
+  max_tokens: 4096
+  num_infers: 1

--- a/model_configs/Qwen2.5-VL-7B-Instruct.yaml
+++ b/model_configs/Qwen2.5-VL-7B-Instruct.yaml
@@ -1,0 +1,25 @@
+tasks:
+  files:
+    - tasks/blink/blink_val.py
+  data_root: /data/BLINK/val/
+  debug: false
+  try_run: true
+  num_workers: 8
+  output_dir: outputs/demo_run_2
+  skip: false
+
+server:
+  local_mode: true
+  quiet: false
+
+model:
+  model_type: http
+  model_name: Qwen2.5-VL-7B-Instruct
+  url: http://localhost:8000/v1/chat/completions
+  api_key: EMPTY
+
+infer:
+  use_cache: true
+  temperature: 0.2
+  max_tokens: 4096
+  num_infers: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "openai",
     "av",
     "accelerate",
+    "omegaconf",
     "word2number"]  
 requires-python = ">=3.10"
 


### PR DESCRIPTION
This PR refactors the project's argument parsing logic, moving away from a complex list of flat CLI arguments to a structured, hierarchical YAML configuration system managed by omegaconf. This change improves maintainability, clarifies parameter grouping (Server, Tasks, Model, Infer), and simplifies the initialization of model adapters.

Key Changes
- Structured Configuration: Introduced RunCfg and sub-configs (ServerCfg, TasksCfg, InferCfg) in flagevalmm/server/utils.py to define default behaviors and types.
- Config-Driven Execution: eval.py and run_server.py now primarily rely on a --cfg file, drastically reducing the complexity of CLI parsing.
- Adapter Interface Update: Updated BaseModelAdapter to parse these structured configs. Added build_task_info to allow adapters to map specific config sections to their internal task_info dictionary.
- Example Configs: Added sample YAML configurations for Qwen2.5-VL to demonstrate the new usage.