### PR TITLE
support multi-endpoint model evaluation for parallel inference

### DIFF
--- a/flagevalmm/eval.py
+++ b/flagevalmm/eval.py
@@ -39,7 +39,10 @@ def update_cfg_from_args(args):
         cfg["output_dir"] = args.output_dir
     else:
         if args.cfg and "model_name" in cfg:
-            model_name = cfg["model_name"].split("/")[-1]
+            model_name_value = cfg["model_name"]
+            if isinstance(model_name_value, list):
+                model_name_value = model_name_value[0]
+            model_name = model_name_value.split("/")[-1]
             cfg["output_dir"] = cfg.get(
                 "output_dir", f"{model_name}_{time.strftime('%Y%m%d_%H%M%S')}"
             )

--- a/flagevalmm/models/base_model_adapter.py
+++ b/flagevalmm/models/base_model_adapter.py
@@ -158,6 +158,8 @@ class BaseModelAdapter:
             task_info.update(extra_cfg)
         self.task_info = task_info
         self.model_name: str = task_info.get("model_name", None)
+        if isinstance(self.model_name, list):
+            self.model_name = self.model_name[0]
         if self.model_name is None and "model_path" in task_info:
             self.model_name = osp.basename(task_info["model_path"])
         if not task_info.get("model_path"):

--- a/model_zoo/vlm/api_model/model_adapter.py
+++ b/model_zoo/vlm/api_model/model_adapter.py
@@ -52,10 +52,8 @@ class ModelAdapter(BaseModelAdapter):
         self.cleanup()
         os._exit(0)
 
-    def model_init(self, task_info: Dict):
-        if task_info.get("backend", None):
-            self.model_server = self.launch_model(task_info)
-
+    def _build_model_config(self, task_info: Dict) -> Dict:
+        """Extract model config keys from task_info."""
         model_config_keys = [
             "model_name",
             "url",
@@ -77,8 +75,14 @@ class ModelAdapter(BaseModelAdapter):
             "provider",
             "retry_time",
         ]
+        return {k: task_info[k] for k in model_config_keys if k in task_info}
+
+    def model_init(self, task_info: Dict):
+        if task_info.get("backend", None):
+            self.model_server = self.launch_model(task_info)
+
         print(f"task_info: {task_info}")
-        model_config = {k: task_info[k] for k in model_config_keys if k in task_info}
+        model_config = self._build_model_config(task_info)
 
         model_type_map = {
             "http": HttpClient,
@@ -88,7 +92,39 @@ class ModelAdapter(BaseModelAdapter):
             "hunyuan": Hunyuan,
         }
         model_type = self.model_type or task_info.get("model_type", "http")
-        self.model = model_type_map[model_type](**model_config)
+        model_cls = model_type_map[model_type]
+
+        # Check for multi-endpoint configuration (url is a list)
+        urls = model_config.get("url")
+        if isinstance(urls, list):
+            num_endpoints = len(urls)
+            model_names = model_config.get("model_name")
+            api_keys = model_config.get("api_key")
+            if not isinstance(model_names, list):
+                model_names = [model_names] * num_endpoints
+            if not isinstance(api_keys, list):
+                api_keys = [api_keys] * num_endpoints
+            assert len(model_names) == num_endpoints, (
+                f"model_name list length ({len(model_names)}) must match "
+                f"url list length ({num_endpoints})"
+            )
+            assert len(api_keys) == num_endpoints, (
+                f"api_key list length ({len(api_keys)}) must match "
+                f"url list length ({num_endpoints})"
+            )
+
+            self.models = []
+            for i in range(num_endpoints):
+                cfg = model_config.copy()
+                cfg["url"] = urls[i]
+                cfg["model_name"] = model_names[i]
+                cfg["api_key"] = api_keys[i]
+                self.models.append(model_cls(**cfg))
+            self.model = self.models[0]
+            logger.info(f"Multi-endpoint mode: created {num_endpoints} model instances")
+        else:
+            self.model = model_cls(**model_config)
+            self.models = [self.model]
 
     def launch_model(self, task_info: Dict):
         if task_info.get("server_port"):
@@ -149,7 +185,9 @@ class ModelAdapter(BaseModelAdapter):
 
         return {"answer": answer, "reason": reason, "usage": usage_info}
 
-    def process_single_item(self, i, inter_results_dir):
+    def process_single_item(self, i, inter_results_dir, model=None):
+        if model is None:
+            model = self.model
         question_id, multi_modal_data, qs = self.dataset[i]
         inter_results_file = osp.join(inter_results_dir, f"{question_id}.json")
         if osp.exists(inter_results_file):
@@ -170,8 +208,8 @@ class ModelAdapter(BaseModelAdapter):
         logger.info(qs)
 
         try:
-            messages = self.model.build_message(qs, multi_modal_data=multi_modal_data)
-            result = self.model.infer(messages)
+            messages = model.build_message(qs, multi_modal_data=multi_modal_data)
+            result = model.infer(messages)
 
             if isinstance(result, list):
                 # Multiple inferences case
@@ -240,11 +278,28 @@ class ModelAdapter(BaseModelAdapter):
         num_workers = self.task_info.get("num_workers", 1)
         inter_results_dir = osp.join(meta_info["output_dir"], "items")
         os.makedirs(inter_results_dir, exist_ok=True)
-        with ThreadPoolExecutor(max_workers=num_workers) as executor:
-            future_to_item = {
-                executor.submit(self.process_single_item, i, inter_results_dir): i
-                for i in range(len(self.dataset))
-            }
+
+        num_endpoints = len(self.models)
+        total_items = len(self.dataset)
+
+        if num_endpoints > 1:
+            logger.info(
+                f"Multi-endpoint mode: distributing {total_items} items "
+                f"across {num_endpoints} endpoints, "
+                f"{num_workers} workers per endpoint"
+            )
+
+        # Assign each item to an endpoint via round-robin
+        # Total concurrency = num_workers * num_endpoints
+        max_workers = num_workers * num_endpoints
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_item = {}
+            for i in range(total_items):
+                model = self.models[i % num_endpoints]
+                future = executor.submit(
+                    self.process_single_item, i, inter_results_dir, model
+                )
+                future_to_item[future] = i
 
             for future in as_completed(future_to_item):
                 result = future.result()

--- a/tasks/mmmu_pro/mmmu_pro_standard_test.py
+++ b/tasks/mmmu_pro/mmmu_pro_standard_test.py
@@ -1,6 +1,6 @@
 config = dict(
     dataset_path="MMMU/MMMU_Pro",
-    dataset_name="standard",
+    dataset_name="standard (10 options)",
     split="test",
     processed_dataset_path="MMMU_Pro",
     processor="../mmmu/process.py",


### PR DESCRIPTION
## Summary
- Support multiple API endpoints for the same model by allowing `url`, `api_key`, and `model_name` to be lists in model config JSON files. Items are distributed across endpoints via round-robin with total concurrency = `num_workers * num_endpoints`.
- Fix MMMU_Pro dataset config: HuggingFace renamed `standard` to `standard (10 options)`.

## Usage
Support new config format with multi-endpoint:

```
  Single endpoint (unchanged):
  { "url": "https://...", "model_name": "model", "api_key": "key" }

  Multi-endpoint:
  {
    "url": ["https://host1:8000/v1/chat/completions", "https://host2:8000/v1/chat/completions"],
    "model_name": "same-model",
    "api_key": "same-key"
  }

  Or with different keys/names per endpoint:
  {
    "url": ["https://host1/...", "https://host2/..."],
    "model_name": ["model-a", "model-b"],
    "api_key": ["key1", "key2"]
  }
```

## Test plan
- [x] Verified single-endpoint config still works (backward compatible)
- [x] Verified multi-endpoint config (3 endpoints) produces identical results to single-endpoint (accuracy 50.31 on textvqa debug)
- [x] Verified mmmu_pro_standard_test runs successfully with updated dataset name
