### PR TITLE
Add Spatial-DISE benchmark task

### DIFF
--- a/tasks/spatial_dise/process.py
+++ b/tasks/spatial_dise/process.py
@@ -10,6 +10,16 @@ from huggingface_hub import snapshot_download
 
 
 BENCHMARK_CSV = "DISE-bench/DISE-benchmark.csv"
+IMAGE_COLUMNS = [
+    ("image", "merged full image"),
+    ("question_image_path", "separate question image"),
+    ("question_image_1_path", "separate question image 1"),
+    ("question_image_2_path", "separate question image 2"),
+    ("option_a_image_path", "separate option A image"),
+    ("option_b_image_path", "separate option B image"),
+    ("option_c_image_path", "separate option C image"),
+    ("option_d_image_path", "separate option D image"),
+]
 
 
 def process(cfg):
@@ -32,21 +42,28 @@ def process(cfg):
     content = []
     missing = []
     for row_id, row in tqdm.tqdm(raw.iterrows(), total=len(raw)):
-        member = _csv_path_to_tar_member(row["image"])
-        shard = tar_index.get(member)
-        if shard is None:
-            missing.append(str(row["image"]))
+        image_refs, row_missing = _image_refs(row, tar_index)
+        if row_missing:
+            missing.extend(row_missing)
+            continue
+        if not image_refs:
+            missing.append(f"image={row.get('image', '')}")
             continue
 
-        img_path = osp.join("images", member)
-        _extract_image(shard, member, osp.join(output_dir, img_path))
+        img_paths = []
+        for ref in image_refs:
+            img_path = osp.join("images", ref["path"])
+            _extract_image(ref["shard"], ref["path"], osp.join(output_dir, img_path))
+            img_paths.append(img_path)
+
         content.append(
             {
                 "question_id": f"benchmark_{row_id}",
-                "question": str(row["question"]).strip(),
+                "question": _question_with_image_order(str(row["question"]).strip(), image_refs),
                 "question_type": "multiple-choice",
                 "answer": str(row["answer"]).strip().upper(),
-                "img_path": img_path,
+                "img_path": img_paths,
+                "image_roles": [ref["role"] for ref in image_refs],
                 "category": str(row.get("category", "")).strip(),
                 "difficulty": str(row.get("difficulty", "")).strip(),
                 "source": str(row.get("source", "")).strip(),
@@ -85,6 +102,39 @@ def _csv_path_to_tar_member(path: str) -> str:
     if path.startswith("images/"):
         path = path[len("images/") :]
     return path.lstrip("/\\")
+
+
+def _image_refs(row, tar_index: dict) -> tuple:
+    refs = []
+    missing = []
+    seen = set()
+    for column, role in IMAGE_COLUMNS:
+        value = row.get(column, "")
+        if pd.isna(value):
+            continue
+        value = str(value).strip()
+        if not value:
+            continue
+        member = _csv_path_to_tar_member(value)
+        if member in seen:
+            continue
+        shard = tar_index.get(member)
+        if shard is None:
+            missing.append(f"{column}={value}")
+            continue
+        refs.append({"role": role, "path": member, "shard": shard})
+        seen.add(member)
+    return refs, missing
+
+
+def _question_with_image_order(question: str, image_refs: list) -> str:
+    image_tokens = " ".join(f"<image {idx + 1}>" for idx in range(len(image_refs)))
+    image_order = "; ".join(f"<image {idx + 1}>: {ref['role']}" for idx, ref in enumerate(image_refs))
+    return (
+        f"{image_tokens}\n"
+        f"Images are provided in order ({image_order}). Use all images together.\n"
+        f"{question}"
+    )
 
 
 def _build_tar_index(dataset_root: str) -> dict:

--- a/tasks/spatial_dise/process.py
+++ b/tasks/spatial_dise/process.py
@@ -1,6 +1,7 @@
 import json
 import os
 import os.path as osp
+import string
 import tarfile
 from pathlib import Path
 
@@ -52,6 +53,7 @@ def process(cfg):
         if not image_refs:
             missing.append(f"image={row.get('image', '')}")
             continue
+        option_letters = _option_letters(row.get("options", ""))
 
         img_paths = []
         for ref in image_refs:
@@ -62,9 +64,12 @@ def process(cfg):
         content.append(
             {
                 "question_id": f"benchmark_{row_id}",
-                "question": _format_question(str(row["question"]).strip(), image_refs, image_mode),
+                "question": _format_question(
+                    str(row["question"]).strip(), image_refs, image_mode, option_letters
+                ),
                 "question_type": "multiple-choice",
                 "answer": str(row["answer"]).strip().upper(),
+                "option_letters": option_letters,
                 "img_path": img_paths,
                 "image_roles": [ref["role"] for ref in image_refs],
                 "image_mode": image_mode,
@@ -132,9 +137,21 @@ def _image_refs(row, tar_index: dict, image_mode: str) -> tuple:
     return refs, missing
 
 
-def _format_question(question: str, image_refs: list, image_mode: str) -> str:
+def _option_letters(value) -> list:
+    if value is None or pd.isna(value):
+        return list("ABCD")
+    letters = []
+    for option in str(value).replace("，", ",").split(","):
+        option = option.strip().upper()
+        if option and option[0] in string.ascii_uppercase and option[0] not in letters:
+            letters.append(option[0])
+    return letters or list("ABCD")
+
+
+def _format_question(question: str, image_refs: list, image_mode: str, option_letters: list) -> str:
+    option_text = ", ".join(option_letters)
     if image_mode != "separate":
-        return question
+        return f"The image contains answer choices labeled {option_text}.\n{question}"
 
     image_tokens = " ".join(f"<image {idx + 1}>" for idx in range(len(image_refs)))
     image_order = "; ".join(
@@ -143,7 +160,7 @@ def _format_question(question: str, image_refs: list, image_mode: str) -> str:
     return (
         f"{image_tokens}\n"
         f"Images are provided as separate question/view/option images ({image_order}). "
-        "Use all images together.\n"
+        f"Use all images together. The answer choices are labeled {option_text}.\n"
         f"{question}"
     )
 

--- a/tasks/spatial_dise/process.py
+++ b/tasks/spatial_dise/process.py
@@ -1,0 +1,115 @@
+import json
+import os
+import os.path as osp
+import tarfile
+from pathlib import Path
+
+import pandas as pd
+import tqdm
+from huggingface_hub import snapshot_download
+
+
+BENCHMARK_CSV = "DISE-bench/DISE-benchmark.csv"
+
+
+def process(cfg):
+    dataset_root = _dataset_root(cfg.dataset_path)
+    output_dir = osp.join(cfg.processed_dataset_path, cfg.split)
+    image_output_dir = osp.join(output_dir, "images")
+    os.makedirs(image_output_dir, exist_ok=True)
+
+    csv_path = osp.join(dataset_root, BENCHMARK_CSV)
+    if not osp.isfile(csv_path):
+        raise FileNotFoundError(f"Spatial-DISE benchmark CSV not found: {csv_path}")
+
+    raw = pd.read_csv(csv_path, skipinitialspace=True)
+    raw.columns = [str(col).strip() for col in raw.columns]
+    for col in raw.columns:
+        if raw[col].dtype == object:
+            raw[col] = raw[col].map(lambda x: x.strip() if isinstance(x, str) else x)
+
+    tar_index = _build_tar_index(dataset_root)
+    content = []
+    missing = []
+    for row_id, row in tqdm.tqdm(raw.iterrows(), total=len(raw)):
+        member = _csv_path_to_tar_member(row["image"])
+        shard = tar_index.get(member)
+        if shard is None:
+            missing.append(str(row["image"]))
+            continue
+
+        img_path = osp.join("images", member)
+        _extract_image(shard, member, osp.join(output_dir, img_path))
+        content.append(
+            {
+                "question_id": f"benchmark_{row_id}",
+                "question": str(row["question"]).strip(),
+                "question_type": "multiple-choice",
+                "answer": str(row["answer"]).strip().upper(),
+                "img_path": img_path,
+                "category": str(row.get("category", "")).strip(),
+                "difficulty": str(row.get("difficulty", "")).strip(),
+                "source": str(row.get("source", "")).strip(),
+                "dise_category": str(row.get("dise_category", "")).strip(),
+            }
+        )
+
+    if missing:
+        examples = ", ".join(missing[:5])
+        raise FileNotFoundError(
+            f"{len(missing)} Spatial-DISE image references were not found in tar shards. "
+            f"Examples: {examples}"
+        )
+
+    with open(osp.join(output_dir, "data.json"), "w") as fout:
+        json.dump(content, fout, indent=2)
+
+
+def _dataset_root(repo_id: str) -> str:
+    local_root = os.environ.get("SPATIAL_DISE_ROOT")
+    if local_root:
+        local_root = osp.expanduser(osp.expandvars(local_root))
+        if osp.isdir(local_root):
+            return local_root
+
+    return snapshot_download(
+        repo_id=repo_id,
+        repo_type="dataset",
+        revision="main",
+        allow_patterns=[BENCHMARK_CSV, "image/*.tar"],
+    )
+
+
+def _csv_path_to_tar_member(path: str) -> str:
+    path = str(path).strip()
+    if path.startswith("images/"):
+        path = path[len("images/") :]
+    return path.lstrip("/\\")
+
+
+def _build_tar_index(dataset_root: str) -> dict:
+    image_dir = osp.join(dataset_root, "image")
+    tar_paths = sorted(Path(image_dir).glob("*.tar"))
+    if not tar_paths:
+        raise FileNotFoundError(f"No Spatial-DISE tar shards found under {image_dir}")
+
+    tar_index = {}
+    for tar_path in tar_paths:
+        with tarfile.open(tar_path) as tf:
+            for member in tf.getmembers():
+                if member.isfile():
+                    tar_index[member.name] = str(tar_path)
+    return tar_index
+
+
+def _extract_image(shard: str, member: str, target: str) -> None:
+    if osp.exists(target):
+        return
+
+    os.makedirs(osp.dirname(target), exist_ok=True)
+    with tarfile.open(shard) as tf:
+        image_file = tf.extractfile(member)
+        if image_file is None:
+            raise FileNotFoundError(f"{member} not found in {shard}")
+        with open(target, "wb") as fout:
+            fout.write(image_file.read())

--- a/tasks/spatial_dise/process.py
+++ b/tasks/spatial_dise/process.py
@@ -10,8 +10,10 @@ from huggingface_hub import snapshot_download
 
 
 BENCHMARK_CSV = "DISE-bench/DISE-benchmark.csv"
-IMAGE_COLUMNS = [
+MERGE_IMAGE_COLUMNS = [
     ("image", "merged full image"),
+]
+SEPARATE_IMAGE_COLUMNS = [
     ("question_image_path", "separate question image"),
     ("question_image_1_path", "separate question image 1"),
     ("question_image_2_path", "separate question image 2"),
@@ -24,6 +26,7 @@ IMAGE_COLUMNS = [
 
 def process(cfg):
     dataset_root = _dataset_root(cfg.dataset_path)
+    image_mode = getattr(cfg, "image_mode", "merge")
     output_dir = osp.join(cfg.processed_dataset_path, cfg.split)
     image_output_dir = osp.join(output_dir, "images")
     os.makedirs(image_output_dir, exist_ok=True)
@@ -42,7 +45,7 @@ def process(cfg):
     content = []
     missing = []
     for row_id, row in tqdm.tqdm(raw.iterrows(), total=len(raw)):
-        image_refs, row_missing = _image_refs(row, tar_index)
+        image_refs, row_missing = _image_refs(row, tar_index, image_mode)
         if row_missing:
             missing.extend(row_missing)
             continue
@@ -59,11 +62,12 @@ def process(cfg):
         content.append(
             {
                 "question_id": f"benchmark_{row_id}",
-                "question": _question_with_image_order(str(row["question"]).strip(), image_refs),
+                "question": _format_question(str(row["question"]).strip(), image_refs, image_mode),
                 "question_type": "multiple-choice",
                 "answer": str(row["answer"]).strip().upper(),
                 "img_path": img_paths,
                 "image_roles": [ref["role"] for ref in image_refs],
+                "image_mode": image_mode,
                 "category": str(row.get("category", "")).strip(),
                 "difficulty": str(row.get("difficulty", "")).strip(),
                 "source": str(row.get("source", "")).strip(),
@@ -104,11 +108,12 @@ def _csv_path_to_tar_member(path: str) -> str:
     return path.lstrip("/\\")
 
 
-def _image_refs(row, tar_index: dict) -> tuple:
+def _image_refs(row, tar_index: dict, image_mode: str) -> tuple:
     refs = []
     missing = []
     seen = set()
-    for column, role in IMAGE_COLUMNS:
+    columns = SEPARATE_IMAGE_COLUMNS if image_mode == "separate" else MERGE_IMAGE_COLUMNS
+    for column, role in columns:
         value = row.get(column, "")
         if pd.isna(value):
             continue
@@ -127,12 +132,18 @@ def _image_refs(row, tar_index: dict) -> tuple:
     return refs, missing
 
 
-def _question_with_image_order(question: str, image_refs: list) -> str:
+def _format_question(question: str, image_refs: list, image_mode: str) -> str:
+    if image_mode != "separate":
+        return question
+
     image_tokens = " ".join(f"<image {idx + 1}>" for idx in range(len(image_refs)))
-    image_order = "; ".join(f"<image {idx + 1}>: {ref['role']}" for idx, ref in enumerate(image_refs))
+    image_order = "; ".join(
+        f"<image {idx + 1}>: {ref['role']}" for idx, ref in enumerate(image_refs)
+    )
     return (
         f"{image_tokens}\n"
-        f"Images are provided in order ({image_order}). Use all images together.\n"
+        f"Images are provided as separate question/view/option images ({image_order}). "
+        "Use all images together.\n"
         f"{question}"
     )
 

--- a/tasks/spatial_dise/spatial_dise.py
+++ b/tasks/spatial_dise/spatial_dise.py
@@ -10,8 +10,7 @@ dataset = dict(
     prompt_template=dict(
         type="PromptTemplate",
         post_prompt=(
-            "The image contains answer choices labeled A, B, C, and D. Please select the correct "
-            "answer and respond with only one letter: A, B, C, or D."
+            "Please select the correct answer and respond with only one option letter."
         ),
     ),
     config=config,

--- a/tasks/spatial_dise/spatial_dise.py
+++ b/tasks/spatial_dise/spatial_dise.py
@@ -1,0 +1,24 @@
+config = dict(
+    dataset_path="TACPS-liv/Spatial-DISE",
+    split="benchmark",
+    processed_dataset_path="Spatial-DISE",
+    processor="process.py",
+)
+
+dataset = dict(
+    type="VqaBaseDataset",
+    prompt_template=dict(
+        type="PromptTemplate",
+        post_prompt=(
+            "The image contains answer choices labeled A, B, C, and D. "
+            "Please select the correct answer and respond with only one letter: A, B, C, or D."
+        ),
+    ),
+    config=config,
+    name="spatial_dise",
+)
+
+evaluator = dict(
+    type="BaseEvaluator",
+    detailed_keys=["category", "difficulty", "dise_category"],
+)

--- a/tasks/spatial_dise/spatial_dise.py
+++ b/tasks/spatial_dise/spatial_dise.py
@@ -10,8 +10,8 @@ dataset = dict(
     prompt_template=dict(
         type="PromptTemplate",
         post_prompt=(
-            "The image contains answer choices labeled A, B, C, and D. "
-            "Please select the correct answer and respond with only one letter: A, B, C, or D."
+            "Use all provided images together. Please select the correct answer and respond with "
+            "only one letter: A, B, C, or D."
         ),
     ),
     config=config,

--- a/tasks/spatial_dise/spatial_dise_separate.py
+++ b/tasks/spatial_dise/spatial_dise_separate.py
@@ -1,8 +1,9 @@
 config = dict(
     dataset_path="TACPS-liv/Spatial-DISE",
     split="benchmark",
-    processed_dataset_path="Spatial-DISE",
+    processed_dataset_path="Spatial-DISE-separate",
     processor="process.py",
+    image_mode="separate",
 )
 
 dataset = dict(
@@ -10,12 +11,12 @@ dataset = dict(
     prompt_template=dict(
         type="PromptTemplate",
         post_prompt=(
-            "The image contains answer choices labeled A, B, C, and D. Please select the correct "
-            "answer and respond with only one letter: A, B, C, or D."
+            "The answer choices are labeled A, B, C, and D. Please select the correct answer and "
+            "respond with only one letter: A, B, C, or D."
         ),
     ),
     config=config,
-    name="spatial_dise",
+    name="spatial_dise_separate",
 )
 
 evaluator = dict(

--- a/tasks/spatial_dise/spatial_dise_separate.py
+++ b/tasks/spatial_dise/spatial_dise_separate.py
@@ -11,8 +11,7 @@ dataset = dict(
     prompt_template=dict(
         type="PromptTemplate",
         post_prompt=(
-            "The answer choices are labeled A, B, C, and D. Please select the correct answer and "
-            "respond with only one letter: A, B, C, or D."
+            "Please select the correct answer and respond with only one option letter."
         ),
     ),
     config=config,


### PR DESCRIPTION
## Summary
- Adds Spatial-DISE as a FlagEvalMM VQA-style multiple-choice benchmark task.
- Uses the official Hugging Face dataset `TACPS-liv/Spatial-DISE` and the official benchmark split at `DISE-bench/DISE-benchmark.csv`.
- Provides two image input modes: `spatial_dise` uses the merged full image, and `spatial_dise_separate` uses separate question/view/option images.

## Scope
- Adds `tasks/spatial_dise/spatial_dise.py` for merged-image evaluation.
- Adds `tasks/spatial_dise/spatial_dise_separate.py` for separate-image evaluation.
- Adds `tasks/spatial_dise/process.py` preprocessing logic for the 559-sample Spatial-DISE benchmark.
- Handles per-sample option letters from the CSV, including A-F cases.
- Does not change shared dataset, evaluator, model, or metric code.

## Validation
- `python3 -m py_compile tasks/spatial_dise/process.py tasks/spatial_dise/spatial_dise.py tasks/spatial_dise/spatial_dise_separate.py` passed.
- `git diff --check` passed.
- Local smoke test with `SPATIAL_DISE_ROOT=/LOCAL2/hxm826/Spatial-DISE-hf` passed: first benchmark sample resolves 1 image in `merge` mode and 6 images in `separate` mode, with no missing tar members.
- Local A-F smoke test passed on a real E-answer sample: prompt includes `A, B, C, D, E, F` in both modes.

## Notes
- Spatial-DISE is an ICLR 2026 benchmark for evaluating multimodal spatial reasoning.
- Both modes ask models to return only one option letter.